### PR TITLE
feat: add rate limiting to API endpoints

### DIFF
--- a/GM_Buddy.Server/Controllers/AccountController.cs
+++ b/GM_Buddy.Server/Controllers/AccountController.cs
@@ -2,6 +2,7 @@ using GM_Buddy.Contracts.DbEntities;
 using GM_Buddy.Contracts.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using System.Security.Claims;
 
 namespace GM_Buddy.Server.Controllers;
@@ -33,6 +34,7 @@ public class AccountController : ControllerBase
     /// </summary>
     [HttpPost("sync")]
     [Authorize]
+    [EnableRateLimiting("sensitive")]
     public async Task<ActionResult<AccountResponse>> SyncAccount([FromBody] SyncAccountRequest request)
     {
         // Extract cognitoSub from JWT token (the 'sub' claim) - NEVER trust it from request body
@@ -100,6 +102,7 @@ public class AccountController : ControllerBase
     /// </summary>
     [HttpDelete]
     [Authorize]
+    [EnableRateLimiting("sensitive")]
     public async Task<ActionResult> DeleteAccount()
     {
         var cognitoSubClaim = User.FindFirst(ClaimTypes.NameIdentifier);
@@ -130,6 +133,7 @@ public class AccountController : ControllerBase
     /// </summary>
     [HttpGet("export")]
     [Authorize]
+    [EnableRateLimiting("sensitive")]
     public async Task<ActionResult> ExportAccountData()
     {
         var cognitoSubClaim = User.FindFirst(ClaimTypes.NameIdentifier);

--- a/GM_Buddy.Server/Program.cs
+++ b/GM_Buddy.Server/Program.cs
@@ -21,6 +21,12 @@ WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
     options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+
+    // Clear default loopback-only restrictions so headers from non-loopback proxies are trusted.
+    // ForwardLimit = 1 means we trust exactly one hop (the immediate proxy/LB).
+    options.KnownNetworks.Clear();
+    options.KnownProxies.Clear();
+    options.ForwardLimit = 1;
 });
 
 builder.AddServiceDefaults();

--- a/GM_Buddy.Server/Program.cs
+++ b/GM_Buddy.Server/Program.cs
@@ -11,6 +11,8 @@ using Microsoft.OpenApi.Models;
 using System.IO.Compression;
 using System.Net;
 using System.Net.Security;
+using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.RateLimiting;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -156,6 +158,42 @@ builder.Services.AddSwaggerGen(c =>
     });
 });
 
+// Rate Limiting Configuration
+builder.Services.AddRateLimiter(options =>
+{
+    // Return 429 Too Many Requests with Retry-After header
+    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+    options.OnRejected = async (context, cancellationToken) =>
+    {
+        context.HttpContext.Response.ContentType = "application/json";
+        if (context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter))
+        {
+            context.HttpContext.Response.Headers.RetryAfter = ((int)retryAfter.TotalSeconds).ToString();
+        }
+        await context.HttpContext.Response.WriteAsync(
+            """{"error":"Too many requests. Please try again later."}""", cancellationToken);
+    };
+
+    // Global policy: 60 requests per minute per IP
+    options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(httpContext =>
+        RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 60,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0
+            }));
+
+    // Stricter policy for sensitive account endpoints (sync, delete)
+    options.AddFixedWindowLimiter("sensitive", limiterOptions =>
+    {
+        limiterOptions.PermitLimit = 10;
+        limiterOptions.Window = TimeSpan.FromMinutes(1);
+        limiterOptions.QueueLimit = 0;
+    });
+});
+
 // CORS Configuration - allow both HTTP and HTTPS for local dev
 builder.Services.AddCors(options =>
 {
@@ -207,6 +245,9 @@ app.UseMiddleware<MetricsLoggingMiddleware>();
 
 // CORS must come BEFORE Authentication/Authorization and MapControllers
 app.UseCors("AllowSpecificOrigins");
+
+// Rate limiting - after CORS so preflight requests aren't rate-limited
+app.UseRateLimiter();
 
 // Output Cache for API responses
 app.UseOutputCache();

--- a/GM_Buddy.Server/Program.cs
+++ b/GM_Buddy.Server/Program.cs
@@ -12,9 +12,16 @@ using System.IO.Compression;
 using System.Net;
 using System.Net.Security;
 using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.RateLimiting;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+// Configure forwarded headers so rate limiting uses real client IPs behind reverse proxy/load balancer
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+});
 
 builder.AddServiceDefaults();
 
@@ -168,7 +175,12 @@ builder.Services.AddRateLimiter(options =>
         context.HttpContext.Response.ContentType = "application/json";
         if (context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter))
         {
-            context.HttpContext.Response.Headers.RetryAfter = ((int)retryAfter.TotalSeconds).ToString();
+            var retryAfterSeconds = (int)Math.Ceiling(retryAfter.TotalSeconds);
+            if (retryAfterSeconds < 1)
+            {
+                retryAfterSeconds = 1;
+            }
+            context.HttpContext.Response.Headers.RetryAfter = retryAfterSeconds.ToString();
         }
         await context.HttpContext.Response.WriteAsync(
             """{"error":"Too many requests. Please try again later."}""", cancellationToken);
@@ -185,13 +197,16 @@ builder.Services.AddRateLimiter(options =>
                 QueueLimit = 0
             }));
 
-    // Stricter policy for sensitive account endpoints (sync, delete)
-    options.AddFixedWindowLimiter("sensitive", limiterOptions =>
-    {
-        limiterOptions.PermitLimit = 10;
-        limiterOptions.Window = TimeSpan.FromMinutes(1);
-        limiterOptions.QueueLimit = 0;
-    });
+    // Stricter policy for sensitive account endpoints (sync, delete) - per IP
+    options.AddPolicy("sensitive", httpContext =>
+        RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 10,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0
+            }));
 });
 
 // CORS Configuration - allow both HTTP and HTTPS for local dev
@@ -215,6 +230,9 @@ builder.Services.AddCors(options =>
 WebApplication app = builder.Build();
 
 app.MapDefaultEndpoints();
+
+// Process forwarded headers first so downstream middleware sees real client IPs
+app.UseForwardedHeaders();
 
 app.UseDefaultFiles();
 app.UseStaticFiles();


### PR DESCRIPTION
Adds built-in .NET 9 rate limiting with:
- Global policy: 60 requests/minute per IP across all endpoints
- Stricter "sensitive" policy: 10 requests/minute on account sync, delete, and export endpoints
- Returns 429 with Retry-After header when limit exceeded

https://claude.ai/code/session_012qe8SCFnqg6pzBQTmdoS83